### PR TITLE
Fixed Opal CDN URL

### DIFF
--- a/src/web/index.html
+++ b/src/web/index.html
@@ -1,8 +1,8 @@
 <html>
 <head>
 <meta charset="utf-8">
-  <script type="text/javascript" src="http://cdn.opalrb.org/opal/current/opal.min.js"></script>
-<script type="text/javascript" src="http://cdn.opalrb.org/opal/current/opal-parser.min.js"></script>
+  <script type="text/javascript" src="http://cdn.opalrb.com/opal/current/opal.min.js"></script>
+<script type="text/javascript" src="http://cdn.opalrb.com/opal/current/opal-parser.min.js"></script>
 <script type="text/javascript" src="https://code.jquery.com/jquery-1.11.3.min.js"></script>
 <!-- JS File -->
 <script type="text/javascript" src="tomrc.js"> </script>


### PR DESCRIPTION
`opalrb.org` seems to point to a casino's site.  `cdn.opalrb.com` is a valid CDN.